### PR TITLE
Skip timeline processing when there is no data

### DIFF
--- a/readTimeline.js
+++ b/readTimeline.js
@@ -18,6 +18,10 @@ function read() {
 	m.get('timelines/public', { only_media: true, limit: 40,  ...extra }).then(resp => {
 		const data = resp.data.filter(p => p.account.bot === false);
 
+		if (!data.length) {
+			return;
+		}
+
 		const accountDomains = data.map(p => p.account.acct.split('@')[1]).filter(p => !!p)
 		const uniqueDomains = Array.from(new Set(accountDomains));
 


### PR DESCRIPTION
## Context

- When there are no posts between runs, an exception occurs; this may be relevant for smaller instances.
- How to reproduce: run `readTimeline` twice in a row.

```
Unhandled rejection TypeError: Cannot read property 'id' of undefined
    at /home/river/AltTextHealthCheck/readTimeline.js:33:44
    at tryCatcher (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/promise.js:729:18)
    at _drainQueueStep (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/home/river/AltTextHealthCheck/node_modules/bluebird/js/release/async.js:15:14)
    at processImmediate (internal/timers.js:464:21)
```

## Suggestion

- Execute the processing of a batch of posts conditionally.
- An early return has been added.